### PR TITLE
feat: add review-resolve workflow for automated PR comment resolution

### DIFF
--- a/.github/workflows/review-resolve.yml
+++ b/.github/workflows/review-resolve.yml
@@ -34,6 +34,7 @@ jobs:
               ...context.repo,
               labels: 'review-fix',
               state: 'open',
+              per_page: 100,
             });
             const existing = issues.find(i =>
               i.title.includes(`PR #${prNumber}`)
@@ -52,16 +53,18 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            const reviewId = context.payload.review.id;
 
-            const { data: comments } = await github.rest.pulls.listReviewComments({
-              ...context.repo,
-              pull_number: prNumber,
-            });
+            const comments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              { ...context.repo, pull_number: prNumber, per_page: 100 }
+            );
 
-            // Filter to bot-authored comments only
+            // Filter to bot-authored comments from the triggering review only
             const botComments = comments.filter(c =>
-              c.user.type === 'Bot'
-              || ['github-actions[bot]', 'copilot[bot]'].includes(c.user.login)
+              c.pull_request_review_id === reviewId
+              && (c.user.type === 'Bot'
+                || ['github-actions[bot]', 'copilot[bot]'].includes(c.user.login))
             );
 
             if (botComments.length === 0) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,18 +180,20 @@ environment restrictions, triggering fallback to the next adapter.
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `auto-merge-non-main.yml` | PR opened/synced | Auto-squash-merge PRs to non-main branches |
-| `doc-sync.md` (gh-aw) | Weekly (Sun 9am UTC) | Documentation freshness audit |
-| `phase11-health.md` (gh-aw) | Weekly (Mon 9:30am UTC) | Repository hygiene audit |
+| `doc-sync.md` (gh-aw)¹ | Weekly (Sun 9am UTC) | Documentation freshness audit |
+| `phase11-health.md` (gh-aw)¹ | Weekly (Mon 9:30am UTC) | Repository hygiene audit |
 | `review-resolve.yml` | `pull_request_review` submitted | Forward bot review comments to Copilot Coding Agent |
+
+> ¹ `gh-aw` entries are markdown-driven workflow specs, not GitHub Actions YAML files.
 
 ### Review Comment Resolver
 
 When an automated reviewer submits a `changes_requested` review, the `review-resolve`
 workflow:
 
-1. Checks for an existing open `review-fix` issue for the same PR (dedup)
+1. Checks for an existing open issue with the `review-fix` label for the same PR (dedup)
 2. Collects all bot-authored inline review comments
-3. Creates a structured GitHub issue assigned to `copilot-swe-agent`
+3. Creates a structured GitHub issue assigned to `copilot-swe-agent` and applies the `review-fix` and `automated` labels
 4. Posts a tracking comment on the original PR
 
 Copilot Coding Agent then autonomously creates a follow-up PR resolving the comments.


### PR DESCRIPTION
## Summary
- Adds `review-resolve.yml` GitHub Actions workflow that triggers when automated reviewers submit `changes_requested` reviews
- Collects all bot-authored inline review comments, creates a structured GitHub issue assigned to `copilot-swe-agent` (Copilot Coding Agent), which then autonomously creates a follow-up PR with fixes
- Includes dedup logic (skips if an open `review-fix` issue already exists for the PR) and posts a tracking comment on the original PR
- Documents the new workflow in AGENTS.md CI/CD Workflows section

## Test plan
- [ ] Verify YAML syntax passes CI linting
- [ ] Ensure Copilot Coding Agent is enabled on the repo and `copilot-swe-agent` has access
- [ ] Create `review-fix` and `automated` labels in the repository
- [ ] Create a test PR and have a bot submit a `changes_requested` review with inline comments
- [ ] Verify workflow triggers, creates a structured issue, and posts a tracking comment
- [ ] Verify dedup: submit a second review on the same PR — no duplicate issue should be created
- [ ] Verify Copilot Coding Agent picks up the issue and creates a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to collect bot review comments, deduplicate existing fixes, create tracking issues, and post status updates on pull requests
* **Documentation**
  * Updated CI/CD documentation to describe the new review comment resolver workflow and its operation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->