### PR TITLE
fix: allowlist bot reviewers in gh-aw pre_activation

### DIFF
--- a/.github/workflows/review-resolve.lock.yml
+++ b/.github/workflows/review-resolve.lock.yml
@@ -23,10 +23,15 @@
 #
 # Address automated review comments by creating a follow-up PR with fixes
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"d273553e56653abc6750116a452d3855c95ffc40a482f9144fcb4e37d26f3c5c","compiler_version":"v0.48.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"a568bceae70ed20474d2506e9ac6010dc9ee60667a1fc1f93e9813f12b0c322b","compiler_version":"v0.48.4"}
 
 name: "Review Comment Resolver"
 "on":
+  # bots: # Bots processed as bot check in pre-activation job
+  # - gemini-code-assist[bot] # Bots processed as bot check in pre-activation job
+  # - coderabbitai[bot] # Bots processed as bot check in pre-activation job
+  # - github-actions[bot] # Bots processed as bot check in pre-activation job
+  # - copilot[bot] # Bots processed as bot check in pre-activation job
   pull_request_review:
     types:
     - submitted
@@ -1140,6 +1145,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_REQUIRED_ROLES: admin,maintainer,write
+          GH_AW_ALLOWED_BOTS: gemini-code-assist[bot],coderabbitai[bot],github-actions[bot],copilot[bot]
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/review-resolve.md
+++ b/.github/workflows/review-resolve.md
@@ -5,6 +5,7 @@ on:
   pull_request_review:
     types: [submitted]
   workflow_dispatch:
+  bots: ['gemini-code-assist[bot]', 'coderabbitai[bot]', 'github-actions[bot]', 'copilot[bot]']
 engine: copilot
 permissions:
   contents: read

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,7 +167,7 @@
         "filename": ".github/workflows/review-resolve.lock.yml",
         "hashed_secret": "a4fbc895dedf49406d65138d4733c6d6b1b09d0d",
         "is_verified": false,
-        "line_number": 824
+        "line_number": 829
       }
     ],
     "project/infra/arcadedb/env/ci.env": [
@@ -234,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-23T17:35:23Z"
+  "generated_at": "2026-02-23T23:21:45Z"
 }


### PR DESCRIPTION
## Summary

- The review-resolve gh-aw workflow was skipping on bot-submitted reviews because the `pre_activation` job checks the triggering actor's repo permission level
- Bot reviewers (`gemini-code-assist[bot]`, `coderabbitai[bot]`) have permission level `none`, failing the default `admin/maintainer/write` requirement
- Added `on.bots` frontmatter to allowlist the four known bot reviewers, which populates `GH_AW_ALLOWED_BOTS` in the compiled lock file and bypasses the role-based check for those actors

## Changes

- `.github/workflows/review-resolve.md` — added `bots:` allowlist in frontmatter
- `.github/workflows/review-resolve.lock.yml` — recompiled with `gh aw compile`
- `.secrets.baseline` — updated for recompiled lock file

## Test plan

- [ ] Merge this PR to main
- [ ] Wait for a bot review on any open PR (or trigger `workflow_dispatch` manually)
- [ ] Verify the `pre_activation` job passes and the `activation` → `agent` → `safe_outputs` pipeline runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow authorization to explicitly allow specified bot accounts in the Review Comment Resolver workflow.
  * Refreshed workflow metadata and secrets baseline configuration to reflect current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->