### PR TITLE
fix: use event payload for base ref in gh-aw safe_outputs checkout

### DIFF
--- a/.github/workflows/review-resolve.lock.yml
+++ b/.github/workflows/review-resolve.lock.yml
@@ -1203,7 +1203,7 @@ jobs:
         if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref || github.ref_name }}
+          ref: ${{ github.event.pull_request.base.ref || github.base_ref || github.ref_name }}
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
           fetch-depth: 1
@@ -1225,7 +1225,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.base_ref || github.ref_name }}\",\"draft\":false,\"labels\":[\"review-fix\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"fix(review): \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.event.pull_request.base.ref || github.base_ref || github.ref_name }}\",\"draft\":false,\"labels\":[\"review-fix\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"fix(review): \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

- Fix `safe_outputs` job checkout failure when triggered by `pull_request_review` events
- `github.base_ref` is only populated for `pull_request` / `pull_request_target` events — not `pull_request_review`
- Use `github.event.pull_request.base.ref` which is available in the event payload for all PR-related events

## Root cause

The compiled `review-resolve.lock.yml` (generated by gh-aw v0.48.4) uses `github.base_ref || github.ref_name` for the checkout ref. On `pull_request_review` events, `github.base_ref` is empty, so it falls through to `github.ref_name` which resolves to `117/merge` (from `refs/pull/117/merge`). Git then tries to fetch `refs/heads/117/merge` which doesn't exist as a branch, causing the checkout to fail after 3 retries.

## Fix

Prepend `github.event.pull_request.base.ref` to the fallback chain:

```yaml
# Before
ref: ${{ github.base_ref || github.ref_name }}

# After
ref: ${{ github.event.pull_request.base.ref || github.base_ref || github.ref_name }}
```

This correctly resolves to `main` (the PR's base branch) for `pull_request_review` events, while preserving existing behavior for `workflow_dispatch`.

## Test plan

- [ ] Merge to main and trigger the review-resolve workflow on an open PR to verify the `safe_outputs` job passes
- [ ] Verify `workflow_dispatch` still works (falls through to `github.ref_name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow handling to more accurately identify pull request base references across different Git reference scenarios, enhancing build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->