### PR TITLE
fix: restore InterventionReliabilityTests compile for actor ctor changes

### DIFF
--- a/project/dotnet/tests/SwarmAssistant.Runtime.Tests/InterventionReliabilityTests.cs
+++ b/project/dotnet/tests/SwarmAssistant.Runtime.Tests/InterventionReliabilityTests.cs
@@ -453,7 +453,7 @@ public sealed class InterventionReliabilityTests : TestKit
                 taskId, "Task", "desc",
                 workerProbe, reviewerProbe, supervisorProbe, blackboardProbe,
                 ActorRefs.Nobody, roleEngine, goapPlanner, _loggerFactory, _telemetry, uiEvents, registry, _options,
-                null, null, null, 2, 0)));
+                null, null, null, 2, 0, null)));
 
         _registries[suffix] = registry;
         return (taskId, coordinator, registry, uiEvents);
@@ -488,6 +488,8 @@ public sealed class InterventionReliabilityTests : TestKit
                 uiEvents,
                 registry,
                 Options.Create(_options),
+                null,
+                null,
                 null,
                 null)),
             $"disp-{suffix}");


### PR DESCRIPTION
## Summary
- fixes a compile break in `InterventionReliabilityTests` caused by Akka `Props.Create` expression trees calling constructors with omitted optional args
- passes explicit trailing `null` args for `TaskCoordinatorActor` and `DispatcherActor` constructor invocations in the test helper methods

## Why
Expression trees cannot represent method/constructor calls that rely on optional arguments (`CS0854`). The previous test code compiled on older constructor shapes but broke after new optional parameters were added.

## Validation
- `dotnet test project/dotnet/SwarmAssistant.sln --nologo`
  - Passed: 356, Failed: 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to ensure continued compatibility with internal system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->