### PR TITLE
fix(workflow): repair review-resolve safe_outputs ref on pull_request_review

### DIFF
--- a/.github/workflows/review-resolve.lock.yml
+++ b/.github/workflows/review-resolve.lock.yml
@@ -23,7 +23,7 @@
 #
 # Address automated review comments by creating a follow-up PR with fixes
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"a568bceae70ed20474d2506e9ac6010dc9ee60667a1fc1f93e9813f12b0c322b","compiler_version":"v0.48.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"2d5fe8827f11f14060e1dd43c21915f0a457097b6bc6badfa01134693ec23c68","compiler_version":"v0.48.4"}
 
 name: "Review Comment Resolver"
 "on":
@@ -1203,7 +1203,7 @@ jobs:
         if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref || github.ref_name }}
+          ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
           fetch-depth: 1
@@ -1225,7 +1225,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ env.GH_AW_AGENT_OUTPUT }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.base_ref || github.ref_name }}\",\"draft\":false,\"labels\":[\"review-fix\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"fix(review): \"},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"base_branch\":\"${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}\",\"draft\":false,\"labels\":[\"review-fix\",\"automated\"],\"max\":1,\"max_patch_size\":1024,\"title_prefix\":\"fix(review): \"},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/review-resolve.md
+++ b/.github/workflows/review-resolve.md
@@ -19,6 +19,7 @@ tools:
 safe-outputs:
   create-pull-request:
     max: 1
+    base-branch: "${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}"
     title-prefix: "fix(review): "
     labels: [review-fix, automated]
     draft: false


### PR DESCRIPTION
## Summary
- fix `review-resolve` safe output branch resolution for `pull_request_review` events
- replace `github.base_ref || github.ref_name` with `github.event.pull_request.base.ref || github.event.repository.default_branch` so checkout and PR base target real branches
- update workflow source frontmatter and corresponding lock metadata/hash

## Why
`pull_request_review` events set `github.ref_name` like `139/merge`, which caused `safe_outputs` checkout to fetch a non-existent branch and fail before applying any fixes.

## Validation
- `gh aw status` reports `review-resolve` as compiled
- failed run #69 showed checkout attempting `ref: 139/merge`; this patch removes that resolution path

Closes #140


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request automation workflow configuration to improve base branch resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->