### PR TITLE
fix: enable swarm build verification and pre-commit awareness

### DIFF
--- a/project/dotnet/src/SwarmAssistant.Runtime/Execution/RolePromptFactory.cs
+++ b/project/dotnet/src/SwarmAssistant.Runtime/Execution/RolePromptFactory.cs
@@ -49,6 +49,10 @@ internal static class RolePromptFactory
                 "## Implementation Plan",
                 command.PlanningOutput ?? "No plan provided. Infer the necessary changes from the task description.",
                 string.Empty,
+                "## Code Quality",
+                "Pre-commit hooks enforce: no trailing whitespace, files must end with a newline,",
+                "no merge conflict markers. Ensure all produced code satisfies these constraints.",
+                string.Empty,
                 "Produce the minimal code changes to complete this task. Include file paths for each change."),
             SwarmRole.Reviewer => string.Join(
                 Environment.NewLine,

--- a/project/dotnet/src/SwarmAssistant.Runtime/appsettings.Local.json
+++ b/project/dotnet/src/SwarmAssistant.Runtime/appsettings.Local.json
@@ -36,6 +36,7 @@
     "CodeIndexForPlanner": true,
     "CodeIndexForBuilder": true,
     "CodeIndexForReviewer": true,
-    "CodeIndexLanguages": []
+    "CodeIndexLanguages": [],
+    "VerifySolutionPath": "project/dotnet/SwarmAssistant.sln"
   }
 }


### PR DESCRIPTION
## Summary

- Enable `VerifySolutionPath` in `appsettings.Local.json` so the Verify GOAP step (from RFC-009) actually runs `dotnet build` + `dotnet test` during local dogfooding
- Add Code Quality section to builder agent prompt with pre-commit hook constraints (no trailing whitespace, newline at EOF, no merge conflict markers)

## Motivation

RFC-009 dogfooding run had two top failure patterns:
- **29 undetected test failures** passed through the entire planner→builder→reviewer pipeline — the Verify step existed but was inactive (no `VerifySolutionPath` configured)
- **5 files with trailing whitespace** — builder agents had no awareness of pre-commit hook requirements

## Test plan

- [x] 578 tests pass (no regressions)
- [ ] Next dogfooding run (RFC-006) validates reduced gatekeeper fix rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced code quality enforcement with stricter formatting standards
  * Added solution path configuration for system verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->