### PR TITLE
feat(runtime): wire Langfuse+skills learning context into prompt dispatch

### DIFF
--- a/project/dotnet/src/SwarmAssistant.Runtime/Langfuse/LangfuseSimilarityQuery.cs
+++ b/project/dotnet/src/SwarmAssistant.Runtime/Langfuse/LangfuseSimilarityQuery.cs
@@ -60,6 +60,11 @@ public sealed class LangfuseSimilarityQuery : ILangfuseSimilarityQuery
 
             return contextBuilder.ToString();
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Langfuse similarity query timed out or was canceled");
+            return null;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to query Langfuse for similar tasks");

--- a/project/dotnet/src/SwarmAssistant.Runtime/Program.cs
+++ b/project/dotnet/src/SwarmAssistant.Runtime/Program.cs
@@ -104,6 +104,7 @@ if (bootstrapOptions.LangfuseTracingEnabled)
         }
     });
     builder.Services.AddSingleton<ILangfuseApiClient, HttpLangfuseApiClient>();
+    builder.Services.AddSingleton<ILangfuseSimilarityQuery, LangfuseSimilarityQuery>();
     builder.Services.AddSingleton<ILangfuseScoreWriter, LangfuseScoreWriter>();
 }
 if (bootstrapOptions.MemvidEnabled)

--- a/project/dotnet/src/SwarmAssistant.Runtime/Skills/SkillDefinition.cs
+++ b/project/dotnet/src/SwarmAssistant.Runtime/Skills/SkillDefinition.cs
@@ -26,8 +26,9 @@ public sealed record SkillDefinition
             throw new ArgumentException("At least one role is required.", nameof(roles));
 
         if (!scope.Equals("global", StringComparison.OrdinalIgnoreCase) &&
+            !scope.Equals("project", StringComparison.OrdinalIgnoreCase) &&
             !scope.StartsWith("task:", StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("Scope must be 'global' or start with 'task:'.", nameof(scope));
+            throw new ArgumentException("Scope must be 'global', 'project', or start with 'task:'.", nameof(scope));
 
         Name = name;
         Description = description;

--- a/project/dotnet/src/SwarmAssistant.Runtime/Worker.cs
+++ b/project/dotnet/src/SwarmAssistant.Runtime/Worker.cs
@@ -9,6 +9,7 @@ using SwarmAssistant.Runtime.Configuration;
 using SwarmAssistant.Runtime.Execution;
 using SwarmAssistant.Runtime.Langfuse;
 using SwarmAssistant.Runtime.Memvid;
+using SwarmAssistant.Runtime.Skills;
 using SwarmAssistant.Runtime.Tasks;
 using SwarmAssistant.Runtime.Telemetry;
 using SwarmAssistant.Runtime.Ui;
@@ -40,6 +41,7 @@ public sealed class Worker : BackgroundService
     private readonly IOutcomeReader _outcomeReader;
     private readonly ITaskExecutionEventWriter? _eventWriter;
     private readonly ILangfuseScoreWriter? _langfuseScoreWriter;
+    private readonly ILangfuseSimilarityQuery? _langfuseSimilarityQuery;
     private readonly MemvidClient? _memvidClient;
 
     private ActorSystem? _actorSystem;
@@ -61,6 +63,7 @@ public sealed class Worker : BackgroundService
         IOutcomeReader outcomeReader,
         ITaskExecutionEventWriter? eventWriter = null,
         ILangfuseScoreWriter? langfuseScoreWriter = null,
+        ILangfuseSimilarityQuery? langfuseSimilarityQuery = null,
         MemvidClient? memvidClient = null)
     {
         _logger = logger;
@@ -75,6 +78,7 @@ public sealed class Worker : BackgroundService
         _outcomeReader = outcomeReader;
         _eventWriter = eventWriter;
         _langfuseScoreWriter = langfuseScoreWriter;
+        _langfuseSimilarityQuery = langfuseSimilarityQuery;
         _memvidClient = memvidClient;
     }
 
@@ -304,6 +308,40 @@ public sealed class Worker : BackgroundService
             _loggerFactory.CreateLogger<WorkspaceBranchManager>(),
             _options.WorktreeIsolationEnabled);
 
+        SkillMatcher? skillMatcher = null;
+        var skillBasePath = Path.Combine(_options.RepoRootPath ?? Directory.GetCurrentDirectory(), ".agent", "skills");
+        if (Directory.Exists(skillBasePath))
+        {
+            try
+            {
+                var skillIndexBuilder = new SkillIndexBuilder(
+                    _loggerFactory.CreateLogger<SkillIndexBuilder>(),
+                    _loggerFactory);
+                skillIndexBuilder.BuildIndex(skillBasePath);
+                var indexedSkills = skillIndexBuilder.GetAllSkills().Values.ToArray();
+                if (indexedSkills.Length > 0)
+                {
+                    skillMatcher = new SkillMatcher(indexedSkills);
+                    _logger.LogInformation(
+                        "Skill matcher initialized basePath={SkillBasePath} skillCount={SkillCount}",
+                        skillBasePath,
+                        indexedSkills.Length);
+                }
+                else
+                {
+                    _logger.LogInformation("Skill matcher not initialized: no skill definitions found at {SkillBasePath}", skillBasePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to initialize skill matcher from {SkillBasePath}; continuing without skill matching.", skillBasePath);
+            }
+        }
+        else
+        {
+            _logger.LogDebug("Skill base path not found {SkillBasePath}; continuing without skill matching.", skillBasePath);
+        }
+
         var sandboxEnforcer = new SandboxLevelEnforcer(
             containerAvailable: string.Equals(_options.SandboxMode, "docker", StringComparison.OrdinalIgnoreCase)
                              || string.Equals(_options.SandboxMode, "apple-container", StringComparison.OrdinalIgnoreCase));
@@ -339,7 +377,9 @@ public sealed class Worker : BackgroundService
                 buildVerifier,
                 sandboxEnforcer,
                 _langfuseScoreWriter,
-                _memvidClient)),
+                _memvidClient,
+                _langfuseSimilarityQuery,
+                skillMatcher)),
             "dispatcher");
         _actorRegistry.SetDispatcher(dispatcher);
         _dispatcher = dispatcher;

--- a/project/dotnet/tests/SwarmAssistant.Runtime.Tests/AgentRegistryActorTests.cs
+++ b/project/dotnet/tests/SwarmAssistant.Runtime.Tests/AgentRegistryActorTests.cs
@@ -224,7 +224,12 @@ public sealed class AgentRegistryActorTests : TestKit
 
         healthyBudget.ExpectMsg<ExecuteRoleTask>(TimeSpan.FromSeconds(2));
         lowBudget.ExpectNoMsg(TimeSpan.FromMilliseconds(200));
-        Assert.True(new BudgetEnvelope { Type = BudgetType.TokenLimited, TotalTokens = 100, UsedTokens = 90, WarningThreshold = 0.8, HardLimit = 1.0 }.IsLowBudget);
+
+        registry.Tell(new QueryAgents(null, null));
+        var allAgents = ExpectMsg<QueryAgentsResult>();
+        var lowBudgetAgent = allAgents.Agents.FirstOrDefault(a => a.AgentId == "builder-low");
+        Assert.NotNull(lowBudgetAgent);
+        Assert.True(lowBudgetAgent.Budget?.IsLowBudget ?? false);
     }
 
     [Fact]

--- a/project/dotnet/tests/SwarmAssistant.Runtime.Tests/Skills/SkillDefinitionTests.cs
+++ b/project/dotnet/tests/SwarmAssistant.Runtime.Tests/Skills/SkillDefinitionTests.cs
@@ -48,6 +48,22 @@ public sealed class SkillDefinitionTests
     }
 
     [Fact]
+    public void Constructor_WithProjectScope_CreatesInstance()
+    {
+        var definition = new SkillDefinition(
+            name: "ProjectSkill",
+            description: "A project-scoped skill",
+            tags: new[] { "project" },
+            roles: new[] { SwarmRole.Builder },
+            scope: "project",
+            body: "Project-scoped content",
+            sourcePath: "/path/to/project-skill.md"
+        );
+
+        Assert.Equal("project", definition.Scope);
+    }
+
+    [Fact]
     public void SameReference_ReturnsEqual()
     {
         var definition = new SkillDefinition(

--- a/project/dotnet/tests/SwarmAssistant.Runtime.Tests/TaskCoordinatorLearningContextTests.cs
+++ b/project/dotnet/tests/SwarmAssistant.Runtime.Tests/TaskCoordinatorLearningContextTests.cs
@@ -1,0 +1,203 @@
+using Akka.Actor;
+using Akka.TestKit.Xunit2;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using SwarmAssistant.Contracts.Messaging;
+using SwarmAssistant.Contracts.Tasks;
+using SwarmAssistant.Runtime.Actors;
+using SwarmAssistant.Runtime.Configuration;
+using SwarmAssistant.Runtime.Langfuse;
+using SwarmAssistant.Runtime.Planning;
+using SwarmAssistant.Runtime.Skills;
+using SwarmAssistant.Runtime.Tasks;
+using SwarmAssistant.Runtime.Telemetry;
+using SwarmAssistant.Runtime.Ui;
+
+namespace SwarmAssistant.Runtime.Tests;
+
+public sealed class TaskCoordinatorLearningContextTests : TestKit
+{
+    private readonly RuntimeOptions _options = new()
+    {
+        AgentFrameworkExecutionMode = "subscription-cli-fallback",
+        CliAdapterOrder = ["local-echo"],
+        WorkerPoolSize = 1,
+        ReviewerPoolSize = 1,
+        MaxCliConcurrency = 2,
+        SandboxMode = "none",
+    };
+
+    private readonly ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    [Fact]
+    public void PlanAndBuildPrompts_IncludeSkillsAndLangfuseContext_AndLangfuseIsCached()
+    {
+        var parentProbe = CreateTestProbe();
+        var workerProbe = CreateTestProbe();
+        var reviewerProbe = CreateTestProbe();
+        var supervisorProbe = CreateTestProbe();
+        var blackboardProbe = CreateTestProbe();
+        var uiEvents = new UiEventStream();
+        var telemetry = new RuntimeTelemetry(_options, _loggerFactory);
+        var registry = new TaskRegistry(new NoOpTaskMemoryWriter(), NullLogger<TaskRegistry>.Instance);
+        var goapPlanner = new GoapPlanner(SwarmActions.All);
+        var roleEngine = new AgentFrameworkRoleEngine(_options, _loggerFactory, telemetry);
+
+        var taskId = $"learn-{Guid.NewGuid():N}";
+        registry.Register(new TaskAssigned(taskId, "Budget dispatch tuning", "Improve budget-aware task dispatch behavior", DateTimeOffset.UtcNow));
+
+        var langfuse = new FakeLangfuseSimilarityQuery("Similar past task: budget dispatch succeeded");
+        var matcher = new SkillMatcher(
+        [
+            new SkillDefinition(
+                "budget-guard",
+                "Budget lifecycle guidance",
+                ["budget", "dispatch"],
+                [SwarmRole.Planner, SwarmRole.Builder],
+                "global",
+                "Prefer healthy-budget agents before low-budget agents.",
+                "tests")
+        ]);
+
+        var coordinator = parentProbe.ChildActorOf(
+            Props.Create(() => new TaskCoordinatorActor(
+                taskId,
+                "Budget dispatch tuning",
+                "Improve budget-aware task dispatch behavior",
+                workerProbe.Ref,
+                reviewerProbe.Ref,
+                supervisorProbe.Ref,
+                blackboardProbe.Ref,
+                ActorRefs.Nobody,
+                roleEngine,
+                goapPlanner,
+                _loggerFactory,
+                telemetry,
+                uiEvents,
+                registry,
+                _options,
+                null,
+                null,
+                null,
+                2,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                langfuse,
+                matcher)));
+
+        coordinator.Tell(new TaskCoordinatorActor.StartCoordination());
+        workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Orchestrator, TimeSpan.FromSeconds(5));
+
+        coordinator.Tell(new RoleTaskSucceeded(taskId, SwarmRole.Orchestrator, "ACTION: Plan", DateTimeOffset.UtcNow, 1.0, null, "worker"));
+        var plannerTask = workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Planner, TimeSpan.FromSeconds(5));
+        Assert.NotNull(plannerTask.Prompt);
+        Assert.Contains("--- Agent Skills ---", plannerTask.Prompt!, StringComparison.Ordinal);
+        Assert.Contains("Historical Learning (Langfuse)", plannerTask.Prompt!, StringComparison.Ordinal);
+
+        coordinator.Tell(new RoleTaskSucceeded(taskId, SwarmRole.Planner, "plan output with no subtasks", DateTimeOffset.UtcNow, 1.0, null, "worker"));
+        workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Orchestrator, TimeSpan.FromSeconds(5));
+        coordinator.Tell(new RoleTaskSucceeded(taskId, SwarmRole.Orchestrator, "ACTION: Build", DateTimeOffset.UtcNow, 1.0, null, "worker"));
+
+        var builderTask = workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Builder, TimeSpan.FromSeconds(5));
+        Assert.NotNull(builderTask.Prompt);
+        Assert.Contains("--- Agent Skills ---", builderTask.Prompt!, StringComparison.Ordinal);
+        Assert.Contains("Historical Learning (Langfuse)", builderTask.Prompt!, StringComparison.Ordinal);
+        Assert.Equal(1, langfuse.CallCount);
+    }
+
+    [Fact]
+    public void PlanDispatch_WhenLangfuseQueryFails_ContinuesWithoutBlocking()
+    {
+        var parentProbe = CreateTestProbe();
+        var workerProbe = CreateTestProbe();
+        var reviewerProbe = CreateTestProbe();
+        var supervisorProbe = CreateTestProbe();
+        var blackboardProbe = CreateTestProbe();
+        var uiEvents = new UiEventStream();
+        var telemetry = new RuntimeTelemetry(_options, _loggerFactory);
+        var registry = new TaskRegistry(new NoOpTaskMemoryWriter(), NullLogger<TaskRegistry>.Instance);
+        var goapPlanner = new GoapPlanner(SwarmActions.All);
+        var roleEngine = new AgentFrameworkRoleEngine(_options, _loggerFactory, telemetry);
+
+        var taskId = $"learn-failopen-{Guid.NewGuid():N}";
+        registry.Register(new TaskAssigned(taskId, "Langfuse fallback", "Ensure dispatch is fail-open when Langfuse is unavailable", DateTimeOffset.UtcNow));
+        var langfuse = new FakeLangfuseSimilarityQuery(error: new InvalidOperationException("simulated failure"));
+
+        var coordinator = parentProbe.ChildActorOf(
+            Props.Create(() => new TaskCoordinatorActor(
+                taskId,
+                "Langfuse fallback",
+                "Ensure dispatch is fail-open when Langfuse is unavailable",
+                workerProbe.Ref,
+                reviewerProbe.Ref,
+                supervisorProbe.Ref,
+                blackboardProbe.Ref,
+                ActorRefs.Nobody,
+                roleEngine,
+                goapPlanner,
+                _loggerFactory,
+                telemetry,
+                uiEvents,
+                registry,
+                _options,
+                null,
+                null,
+                null,
+                2,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                langfuse,
+                null)));
+
+        coordinator.Tell(new TaskCoordinatorActor.StartCoordination());
+        workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Orchestrator, TimeSpan.FromSeconds(5));
+        coordinator.Tell(new RoleTaskSucceeded(taskId, SwarmRole.Orchestrator, "ACTION: Plan", DateTimeOffset.UtcNow, 1.0, null, "worker"));
+
+        var plannerTask = workerProbe.ExpectMsg<ExecuteRoleTask>(m => m.Role == SwarmRole.Planner, TimeSpan.FromSeconds(5));
+        Assert.NotNull(plannerTask.Prompt);
+        Assert.DoesNotContain("Historical Learning (Langfuse)", plannerTask.Prompt!, StringComparison.Ordinal);
+        Assert.Equal(1, langfuse.CallCount);
+    }
+
+    private sealed class FakeLangfuseSimilarityQuery : ILangfuseSimilarityQuery
+    {
+        private readonly string? _result;
+        private readonly Exception? _error;
+        public int CallCount { get; private set; }
+
+        public FakeLangfuseSimilarityQuery(string? result = null, Exception? error = null)
+        {
+            _result = result;
+            _error = error;
+        }
+
+        public Task<string?> GetSimilarTaskContextAsync(string taskDescription, CancellationToken ct)
+        {
+            CallCount++;
+            if (_error is not null)
+            {
+                throw _error;
+            }
+
+            return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class NoOpTaskMemoryWriter : ITaskMemoryWriter
+    {
+        public Task WriteAsync(TaskSnapshot snapshot, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- wire missing learning-context inputs into task dispatch so prompts can include:
  - matched skills from local `.agent/skills`
  - historical Langfuse similarity context
- add fail-open behavior around learning lookups:
  - Langfuse lookup is timeout-bounded (2s) and non-blocking for dispatch
  - skill matching failures degrade gracefully with warning logs
- register and thread new dependencies through runtime actor wiring:
  - `ILangfuseSimilarityQuery` DI registration
  - worker-level skill index load + `SkillMatcher` creation
  - dispatcher/coordinator constructor plumbing
- make skill parsing compatible with repository skill files by accepting `scope: project`
- include swarm-produced assertion improvement in `AgentRegistryActorTests` (query registry state instead of asserting on a disconnected fixture)

## Tests
- `dotnet test project/dotnet/tests/SwarmAssistant.Runtime.Tests/SwarmAssistant.Runtime.Tests.csproj`
- `MEMVID_INTEGRATION_TESTS=1 dotnet test project/dotnet/tests/SwarmAssistant.Runtime.Tests/SwarmAssistant.Runtime.Tests.csproj --filter "MemvidIntegrationTests|MemvidClientFindModeTests"`

## Dogfood Validation (agent swarm, 2026-02-26)
Runtime: Dogfood profile on `http://127.0.0.1:5091`, adapter order `kilo,kimi`

- task 1: `task-e20d61c9684d4722be7f1f7eb481f2dd` -> `done`
- task 2: `task-8e45a4171d68460bb7f228981a675ce3` -> `done`

Observed runtime evidence:
- Langfuse fail-open path works: `Langfuse similarity query timed out or was canceled`, then dispatch continued
- sibling context still works on follow-up runs:
  - `Sibling context: found 2 sibling stores ...`
  - `Built sibling context from 2 stores (556 chars)`
- additional issue found and fixed during dogfood:
  - skill loader initially rejected repo skills with `scope: project`
  - patched `SkillDefinition` validation to accept `project`
  - runtime then loaded full skill set (`Skill index built: 8 skills, 43 tags`)
